### PR TITLE
Feat: 함수, 렌더링 최적화

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,20 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import "./App.css";
 import Lists from "./components/Lists";
 import Form from "./components/Form";
 
 export default function App() {
-  console.log("app component");
+  console.log("App is rendering");
   const [todoData, setTodoData] = useState([]);
   const [value, setValue] = useState("");
 
+  const handleClick = useCallback(
+    (id) => {
+      let newTodo = todoData.filter((todo) => todo.id !== id);
+      setTodoData(newTodo);
+    },
+    [todoData]
+  );
   return (
     <div className="flex items-center justify-center w-screen h-screen bg-blue-100">
       <div className="w-full p-6 m-4 bg-white rounded shadow lg:w-3/4 lg:max-w-lg">
@@ -15,7 +22,11 @@ export default function App() {
           <h1>Todo List</h1>
         </div>
 
-        <Lists todoData={todoData} setTodoData={setTodoData} />
+        <Lists
+          handleClick={handleClick}
+          todoData={todoData}
+          setTodoData={setTodoData}
+        />
         <Form
           todoData={todoData}
           setValue={setValue}

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Lists from "./components/Lists";
 import Form from "./components/Form";
 
 export default function App() {
+  console.log("app component");
   const [todoData, setTodoData] = useState([]);
   const [value, setValue] = useState("");
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 function Form({ todoData, setValue, setTodoData, value }) {
-  console.log("form component");
+  console.log("Form is rendering");
 
   const handleChange = (e) => {
     setValue(e.target.value);

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,6 +1,8 @@
 import React from "react";
 
 function Form({ todoData, setValue, setTodoData, value }) {
+  console.log("form component");
+
   const handleChange = (e) => {
     setValue(e.target.value);
   };

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -9,6 +9,7 @@ function List({
   provided,
   snapshot,
 }) {
+  console.log("list component");
   const handleCompleteChange = (id) => {
     let newTodo = todoData.map((todo) => {
       if (todo.id === id) {

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -8,8 +8,8 @@ function List({
   setTodoData,
   provided,
   snapshot,
+  handleClick,
 }) {
-  console.log("list component");
   const handleCompleteChange = (id) => {
     let newTodo = todoData.map((todo) => {
       if (todo.id === id) {
@@ -20,10 +20,6 @@ function List({
     setTodoData(newTodo);
   };
 
-  const handleClick = (id) => {
-    let newTodo = todoData.filter((todo) => todo.id !== id);
-    setTodoData(newTodo);
-  };
   return (
     <div
       key={id}

--- a/src/components/Lists.js
+++ b/src/components/Lists.js
@@ -55,4 +55,4 @@ function Lists({ todoData, setTodoData }) {
   );
 }
 
-export default Lists;
+export default React.memo(Lists);

--- a/src/components/Lists.js
+++ b/src/components/Lists.js
@@ -2,7 +2,8 @@ import React from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import List from "./List";
 
-function Lists({ todoData, setTodoData }) {
+function Lists({ todoData, setTodoData, handleClick }) {
+  console.log("Lists is rendering");
   const handleEnd = (result) => {
     console.log(result);
 
@@ -34,6 +35,7 @@ function Lists({ todoData, setTodoData }) {
                 >
                   {(provided, snapshot) => (
                     <List
+                      handleClick={handleClick}
                       todoData={todoData}
                       setTodoData={setTodoData}
                       id={data.id}


### PR DESCRIPTION
closed #5 
- Form에 입력을 하는 경우 Form 컴포넌트와 그 State 값을 가지고 있는 App 컴포넌트만 렌더링이 되어야 하는데, Lists 컴포넌트가 불필요하게 렌더링되는 것을 발견했습니다. React.memo 함수를 이용해 List 컴포넌트를 감싸주어 List 컴포넌트 내의 props가 변경될 때만 렌더링 되도록 수정했습니다.

- App.js에서 handleClick 함수를 props로 내려주어 App -> Lists -> List 컴포넌트에서 사용하도록 했습니다. 그러나 이로 인해 App 컴포넌트가 렌더링될 때마다 handleClick 함수가 다시 생성되고, Lists와 List 컴포넌트도 이 함수를 props로 받기 때문에 함수가 새롭게 만들어져서 불필요한 리렌더링이 발생하게 됩니다. 때문에 handleClick 함수를 useCallback 훅으로 감싸주고, 의존성 배열에 todoData를 추가하여 todoData의 변화가 생겼을 때만 리렌더링 되도록 하였습니다.

